### PR TITLE
fix Date construction for years 0 <= y < 100

### DIFF
--- a/src/Data/JSDate.js
+++ b/src/Data/JSDate.js
@@ -1,6 +1,22 @@
 /* global exports */
 "use strict";
 
+var createDate = function (y, m, d, h, mi, s, ms) {
+  var date = new Date(Date.UTC(y, m, d, h, mi, s, ms));
+  if (y >= 0 && y < 100) {
+    date.setUTCFullYear(y);
+  }
+  return date;
+};
+
+var createLocalDate = function (y, m, d, h, mi, s, ms) {
+  var date = new Date(y, m, d, h, mi, s, ms);
+  if (y >= 0 && y < 100) {
+    date.setFullYear(y);
+  }
+  return date;
+};
+
 exports.isValid = function (date) {
   return !isNaN(date.getTime());
 };
@@ -15,13 +31,12 @@ exports.toInstantImpl = function (just) {
 };
 
 exports.jsdate = function (parts) {
-  var t = Date.UTC(parts.year, parts.month, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond);
-  return new Date(t);
+  return createDate(parts.year, parts.month, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond);
 };
 
 exports.jsdateLocal = function (parts) {
   return function () {
-    return new Date(parts.year, parts.month, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond);
+    return createLocalDate(parts.year, parts.month, parts.day, parts.hour, parts.minute, parts.second, parts.millisecond);
   };
 };
 

--- a/test/Test/Main.purs
+++ b/test/Test/Main.purs
@@ -56,6 +56,7 @@ main = do
 
   log "Check that a roundtrip conversion of a dates results in the input"
   assert $ JSD.toDateTime (JSD.fromDateTime dateTime) == Just dateTime
+  assert $ JSD.toDateTime (JSD.fromDateTime ancientDateTime) == Just ancientDateTime
   assert $ JSD.toDateTime (JSD.fromDateTime bottom) == Just bottom
   assert $ JSD.toDateTime (JSD.fromDateTime top) == Just top
 
@@ -80,3 +81,8 @@ main = do
     DT.Time <$> toEnum 2 <*> toEnum 21 <*> toEnum 43 <*> toEnum 678
 
   dateTime = DT.DateTime date time
+
+  ancientDate = unsafePartial $ fromJust $
+    DT.canonicalDate <$> toEnum 1 <*> pure DT.January <*> toEnum 1
+
+  ancientDateTime = DT.DateTime ancientDate time


### PR DESCRIPTION
Same stuff as https://github.com/purescript/purescript-datetime/pull/53

Turns out that this stuff made my roundtrip property fail:

https://travis-ci.org/berdario/purescript-foreign-datetime/builds/221568479

(weird that this didn't appear before... I don't see any change in the random logic in the latest purescript-jack update)