### PR TITLE
Decode instance.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,8 @@
     "purescript-exceptions": "^3.0.0",
     "purescript-foreign": "^4.0.0",
     "purescript-integers": "^3.0.0",
-    "purescript-now": "^3.0.0"
+    "purescript-now": "^3.0.0",
+    "purescript-foreign-generic": "^5.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^3.0.0",

--- a/src/Data/JSDate.purs
+++ b/src/Data/JSDate.purs
@@ -57,6 +57,7 @@ import Data.DateTime.Instant (Instant)
 import Data.DateTime.Instant as Instant
 import Data.Enum (fromEnum)
 import Data.Foreign (F, Foreign, unsafeReadTagged)
+import Data.Foreign.Class (class Decode)
 import Data.Function.Uncurried (Fn2, runFn2)
 import Data.Int (toNumber)
 import Data.Maybe (Maybe(..))
@@ -73,6 +74,9 @@ foreign import data LOCALE :: Effect
 -- | Attempts to read a `Foreign` value as a `JSDate`.
 readDate :: Foreign -> F JSDate
 readDate = unsafeReadTagged "Date"
+
+instance decodeJSDate :: Decode JSDate where
+  decode = readDate
 
 -- | Checks whether a date value is valid. When a date is invalid, the majority
 -- | of the functions return `NaN`, `"Invalid Date"`, or throw an exception.


### PR DESCRIPTION
Needed for querying date values using [purescript-mysql](https://pursuit.purescript.org/packages/purescript-mysql/0.1.3/docs/MySQL.Connection#v:query_).