### PR TITLE
Remove note about specific effect type

### DIFF
--- a/src/Data/JSDate.purs
+++ b/src/Data/JSDate.purs
@@ -153,8 +153,8 @@ foreign import dateMethod :: forall a. Fn2 String JSDate a
 -- | behaviour for a given string. The RFC2822 and ISO8601 date string formats
 -- | should parse consistently.
 -- |
--- | This function is effectful in the sense that if no time zone is specified
--- | in the string the current locale's time zone will be used instead.
+-- | This function is effectful because if no time zone is specified in the
+-- | string the current locale's time zone will be used instead.
 foreign import parse :: String -> Effect JSDate
 
 -- | Gets a `JSDate` value for the date and time according to the current

--- a/src/Data/JSDate.purs
+++ b/src/Data/JSDate.purs
@@ -153,8 +153,8 @@ foreign import dateMethod :: forall a. Fn2 String JSDate a
 -- | behaviour for a given string. The RFC2822 and ISO8601 date string formats
 -- | should parse consistently.
 -- |
--- | The `LOCALE` effect is present here as if no time zone is specified in the
--- | string the current locale's time zone will be used instead.
+-- | This function is effectful in the sense that if no time zone is specified
+-- | in the string the current locale's time zone will be used instead.
 foreign import parse :: String -> Effect JSDate
 
 -- | Gets a `JSDate` value for the date and time according to the current


### PR DESCRIPTION
This PR removes the reference to the specific `LOCALE` effect in the `parse` docs, as this function now returns a generic `Effect`.