### PR TITLE
Fixes direct dependencies in spago.dhall

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,10 +18,8 @@
   "dependencies": {
     "purescript-datetime": "^5.0.0",
     "purescript-effect": "^3.0.0",
-    "purescript-exceptions": "^5.0.0",
     "purescript-foreign": "^6.0.0",
-    "purescript-integers": "^5.0.0",
-    "purescript-now": "^5.0.0"
+    "purescript-integers": "^5.0.0"
   },
   "devDependencies": {
     "purescript-assert": "^5.0.0",

--- a/spago.dhall
+++ b/spago.dhall
@@ -4,12 +4,17 @@
   , "console"
   , "datetime"
   , "effect"
-  , "exceptions"
+  , "either"
+  , "enums"
   , "foreign"
-  , "numbers"
+  , "functions"
   , "integers"
-  , "now"
+  , "maybe"
+  , "numbers"
+  , "partial"
+  , "prelude"
   , "psci-support"
+  , "transformers"
   ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs", "test/**/*.purs" ]


### PR DESCRIPTION
**Description of the change**
Fixes the dependencies in spago.dhall to pass the CI checks.  Also, removes packages from bower.json that aren't referenced at all, though it doesn't add in the missing direct dependencies.  (See [purescript-contrib/governance#43](https://github.com/purescript-contrib/governance/issues/43))

---

**Checklist:**

- [ ] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
